### PR TITLE
Fix numerical instability of A matrix

### DIFF
--- a/lejepa/multivariate/slicing.py
+++ b/lejepa/multivariate/slicing.py
@@ -139,7 +139,9 @@ class SlicingUnivariateTest(torch.nn.Module):
 
             proj_shape = (x.size(-1), self.num_slices)
             A = torch.randn(proj_shape, **dev, generator=g)
-            A /= A.norm(p=2, dim=0)
+            norms = A.norm(p=2, dim=0)
+            norms = torch.where(norms == 0.0, 1e-4, norms)
+            A /= norms
             self.global_step.add_(1)
 
         stats = self.univariate_test(x @ A)


### PR DESCRIPTION
SIGReg was sometimes returning NaN. This fixes the divided by 0 issue.

Reproducible by the following script on MacBook Air M2.
```python
import lejepa
import torch

torch.set_default_device("mps")
torch.set_default_dtype(torch.bfloat16)

rng = torch.Generator("mps").manual_seed(42)
a = torch.randn((2, 64, 1), generator=rng)

SIGReg = lejepa.multivariate.SlicingUnivariateTest(
    univariate_test=lejepa.univariate.EppsPulley(), num_slices=1024
)
SIGReg.global_step.fill_(5433)

loss = SIGReg(a)
print(SIGReg.global_step, loss)
```